### PR TITLE
Sort events in ascending order by date

### DIFF
--- a/src/views/events/EventData.js
+++ b/src/views/events/EventData.js
@@ -1,6 +1,7 @@
 export const currentYear = 2025
 
 // Array of events for the current year's PyCon
+// Please ensure the events are listed in ascending order by date.
 export const events = [
     {
         date: '1-2 March',
@@ -15,21 +16,22 @@ export const events = [
         link: 'https://pycon.sg',
     },
     {
-        date: '26-27 Sep',
-        title: 'PyCon JP',
-        location: 'Hiroshima, Japan',
-        link: 'https://2025.pycon.jp/',
-    },
-    {
         date: '15-17 August',
         title: 'PyCon KR',
         location: 'Dongguk University, Seoul, South Korea',
         link: 'https://2025.pycon.kr/',
-    }
+    },
+    {
+      date: '26-27 Sep',
+      title: 'PyCon JP',
+      location: 'Hiroshima, Japan',
+      link: 'https://2025.pycon.jp/',
+  },
   ];
 
 
 // Array of upcoming events for the next year
+// Please ensure the events are listed in ascending order by date.
 export const upcomingEvents = [
     // e.g.
     // {


### PR DESCRIPTION
Changes made:
1. Added a comment to remind contributors to keep events sorted by date.
2. Reordered the event objects in ascending order based on their dates.

![image](https://github.com/user-attachments/assets/e478c6d2-c82c-490e-a28b-234026bd10dc)
