### PR TITLE
Fix the whitespace on the right part of the page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -378,6 +378,7 @@ button.button-secondary:hover, button.button-secondary-lg:hover {
 
 .w-fit-avail {
   width: -webkit-fill-available;
+  width: -moz-available;
 }
 
 .h-full {


### PR DESCRIPTION
This fixes the whitespace issue on the right part of the page when using Mozilla Firefox to visit the website. Below is the screenshot of the said issue:

![Screenshot 2025-07-03 at 03-55-17 PyCon APAC](https://github.com/user-attachments/assets/3332eb92-6f72-42ab-9ce6-5d25b8394a60)

To fix this, `-moz-available` is added as the value of the width inside the `w-fit-avail` class.